### PR TITLE
[Feature] Add before_success and before_error callbacks to ResultMonad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
 # Changelog
 
+## 0.4.0
+
+### New features
+
+- Add `before_success` and `before_error` callbacks to `ResultMonad`.
+
 ## 0.3.0
+
+### New features
 
 - Add `ResultMonad` mixin.
 
 ## 0.2.0
+
+### New features
 
 - Add `OptionsDeclaration` mixin.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stimpack (0.3.0)
+    stimpack (0.4.0)
       activesupport (~> 6.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -140,3 +140,33 @@ else
   result.errors
 end
 ```
+
+### Callbacks
+
+The `ResultMonad` mixin exposes two callbacks, `before_success` and
+`before_error`. These can be configured by passing a block to them in the
+class body.
+
+*Note: Callbacks are not inherited, and declaring multiple callbacks in the
+same class will overwrite the previous one.*
+
+**Example:**
+
+```ruby
+class Foo
+  include Stimpack::ResultMonad
+
+  before_success do
+    log_tracking_data
+  end
+
+  private
+
+  def log_tracking_data
+    # ...
+  end
+end
+```
+
+*Note: The block is evaluated in the context of the instance, so you can call
+any instance methods from inside the block.*

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stimpack
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/spec/stimpack/result_monad_spec.rb
+++ b/spec/stimpack/result_monad_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Stimpack::ResultMonad do
       def error_result(errors:)
         error(errors: errors)
       end
+
+      def self.to_s
+        "Foo"
+      end
     end
   end
 
@@ -81,6 +85,36 @@ RSpec.describe Stimpack::ResultMonad do
     end
   end
 
+  describe ".before_success" do
+    let(:instance) { service.new }
+
+    before do
+      allow(instance).to receive(:inspect)
+
+      service.blank_result
+      service.before_success { inspect }
+
+      instance.success_result
+    end
+
+    it { expect(instance).to have_received(:inspect).once }
+  end
+
+  describe ".before_error" do
+    let(:instance) { service.new }
+
+    before do
+      allow(instance).to receive(:inspect)
+
+      service.blank_result
+      service.before_error { inspect }
+
+      instance.error_result(errors: ["foo"])
+    end
+
+    it { expect(instance).to have_received(:inspect).once }
+  end
+
   describe "#success" do
     before { service.result(:foo) }
 
@@ -102,6 +136,6 @@ RSpec.describe Stimpack::ResultMonad do
     let(:instance) { service.new }
 
     it { expect(instance.error_result(errors: ["foo"])).to be_failed }
-    it { expect(instance.error_result(errors: ["foo"]).errors).to eq ["foo"] }
+    it { expect(instance.error_result(errors: ["foo"]).errors).to eq(["foo"]) }
   end
 end


### PR DESCRIPTION
### New feature

The `ResultMonad` mixin exposes two callbacks, `before_success` and `before_error`. These can be configured by passing a block to them in the class body.

*Note: Callbacks are not inherited, and declaring multiple callbacks in the same class will overwrite the previous one.*

**Example:**

```ruby
class Foo
  include Stimpack::ResultMonad

  before_success do
    log_tracking_data
  end

  private

  def log_tracking_data
    # ...
  end
end
```

*Note: The block is evaluated in the context of the instance, so you can call any instance methods from inside the block.*
