### PR TITLE
[Bugfix] Require EventSource by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.1
+
+### Bug fixes
+
+- Require `EventSource` by default.
+
 ## 0.5.0
 
 ### New features

--- a/lib/stimpack.rb
+++ b/lib/stimpack.rb
@@ -2,6 +2,7 @@
 
 require_relative "stimpack/version"
 
+require_relative "stimpack/event_source"
 require_relative "stimpack/functional_object"
 require_relative "stimpack/options_declaration"
 require_relative "stimpack/result_monad"

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stimpack
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
### Bugfix

Require `EventSource` by default.