### PR TITLE
[Feature] Add raise_errors option to EventSource.on method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.2
+
+### New features
+
+- Add `raise_errors` option to `EventSource.on` method.
+
 ## 0.5.1
 
 ### Bug fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stimpack (0.5.0)
+    stimpack (0.5.2)
       activesupport (~> 6.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -48,6 +48,25 @@ Foo.new.bar
 this to perform long-running tasks. You can use the event listener to schedule
 a background job, though!*
 
+### Error handling
+
+By default, all errors that occur in a callback are rescued unhandled. This is
+intentional and by design, since most of the time, we don't want outside code
+invoked by event listener to be able to interrupt the main flow.
+
+If you decide that you want to handle these errors yourself, you can configure
+the listener to re-raise any errors when you register it.
+
+**Example:**
+
+```ruby
+Foo.on(:bar, raise_errors: true) do |event|
+  puts event.message
+rescue StandardError => error
+  log_error(error.message)
+end
+```
+
 ## FunctionalObject
 
 A simple mixin that provides a shorthand notation for instantiating and

--- a/lib/stimpack/event_source.rb
+++ b/lib/stimpack/event_source.rb
@@ -27,6 +27,23 @@ module Stimpack
       end
     end
 
+    class Listener
+      def initialize(raise_errors:, &block)
+        @block = block
+        @raise_errors = raise_errors
+      end
+
+      def call(...)
+        block.(...)
+      rescue StandardError => e
+        raise e if raise_errors
+      end
+
+      private
+
+      attr_reader :raise_errors, :block
+    end
+
     module ClassMethods
       def self.extended(klass)
         klass.class_eval do
@@ -38,8 +55,10 @@ module Stimpack
         end
       end
 
-      def on(event_name, &block)
-        event_listeners["#{self}.#{event_name}"] << block
+      def on(event_name, raise_errors: false, &block)
+        listener = Listener.new(raise_errors: raise_errors, &block)
+
+        event_listeners["#{self}.#{event_name}"] << listener
       end
     end
 

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stimpack
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end

--- a/spec/stimpack/event_source/listener_spec.rb
+++ b/spec/stimpack/event_source/listener_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "stimpack/event_source"
+
+RSpec.describe Stimpack::EventSource::Listener do
+  subject(:listener) { described_class.new(raise_errors: raise_errors, &block) }
+
+  let(:raise_errors) { false }
+
+  describe "#call" do
+    context "when no errors are raised" do
+      let(:receiver) { spy }
+
+      let(:block) do
+        proc { receiver.foo }
+      end
+
+      before do
+        allow(receiver).to receive(:foo)
+
+        listener.()
+      end
+
+      it { expect(receiver).to have_received(:foo).once }
+    end
+
+    context "when errors are raised" do
+      let(:block) do
+        proc { raise StandardError }
+      end
+
+      context "when configured to raise errors" do
+        let(:raise_errors) { true }
+
+        it { expect { listener.() }.to raise_error(StandardError) }
+      end
+
+      context "when configured to not raise errors" do
+        let(:raise_errors) { false }
+
+        it { expect { listener.() }.not_to raise_error }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### New feature

By default, all errors that occur in a callback are rescued unhandled. This is intentional and by design, since most of the time, we don't want outside code invoked by event listener to be able to interrupt the main flow.

If you decide that you want to handle these errors yourself, you can configure the listener to re-raise any errors when you register it.

**Example:**

```ruby
Foo.on(:bar, raise_errors: true) do |event|
  puts event.message
rescue StandardError => error
  log_error(error.message)
end
```