### PR TITLE
Spring cleaning 🧹

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.4
+
+### Maintenance
+
+- Split child classes of `EventSource` and `OptionsDeclaration` into own files.
+- Add a bunch more inline documentation for the mixins.
+- Remove `EventSource` and `ResultMonad` dependencies on ActiveSupport.
+
 ## 0.5.3
 
 ### New features

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stimpack (0.5.3)
+    stimpack (0.5.4)
       activesupport (~> 6.1)
 
 GEM

--- a/lib/stimpack/event_source/event.rb
+++ b/lib/stimpack/event_source/event.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Stimpack
+  module EventSource
+    # A thin wrapper around an event that encapsulates the event name and
+    # data payload. Acts similar to an OpenStruct to simplify access to the
+    # event data and give better error messages when the data is missing.
+    #
+    # Example:
+    #
+    #   event = Event.new("foo", { bar: "Hello, world!" })
+    #
+    #   event.bar
+    #   #=> "Hello world!"
+    #
+    class Event
+      def initialize(name, data = {})
+        @name = name
+        @data = data
+      end
+
+      attr_reader :name, :data
+
+      def respond_to_missing?(method)
+        data.key?(method) || super
+      end
+
+      def method_missing(method, *arguments, &block)
+        if data.key?(method)
+          data[method]
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/stimpack/event_source/listener.rb
+++ b/lib/stimpack/event_source/listener.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Stimpack
+  module EventSource
+    # A thin wrapper around a block with the option to rescue errors and
+    # leave them unhandled. This lets us safely execute registered event
+    # listeners without worrying that they will raise an error and
+    # unexpectedly terminate the program.
+    #
+    class Listener
+      def initialize(raise_errors:, &block)
+        @block = block
+        @raise_errors = raise_errors
+      end
+
+      def call(...)
+        block.(...)
+      rescue StandardError => e
+        raise e if raise_errors
+      end
+
+      private
+
+      attr_reader :raise_errors, :block
+    end
+  end
+end

--- a/lib/stimpack/functional_object.rb
+++ b/lib/stimpack/functional_object.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 module Stimpack
+  # This mixin adds a `#call` class method which instantiates an object and
+  # proxies arguments to the `#call` method. This allows for shorthand
+  # invocation, e.g.:
+  #
+  #   AccruePoints.(user: user, amount: amount)
+  #
+  # which shortens code and aids when stubbing results in tests.
+  #
   module FunctionalObject
     module ClassMethods
-      # Instantiates an object and proxies arguments to the `#call` method.
-      # This allows for shorthand invocation, e.g.:
-      #
-      #   AccruePoints.(user: user, amount: amount)
-      #
-      # which shortens code and aids in stubbing responses.
-      #
       def call(...)
         new(...).()
       end

--- a/lib/stimpack/options_declaration/initializer.rb
+++ b/lib/stimpack/options_declaration/initializer.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Stimpack
+  module OptionsDeclaration
+    # An injectable initializer that assigns options on object creation and
+    # raises an error when required options are missing.
+    #
+    module Initializer
+      def initialize(*_, **options)
+        OptionsAssigner.new(self, options).assign_options!
+
+        yield self if block_given?
+      end
+
+      # This inner class minimizes pollution of the consumer class by
+      # encapsulating the methods needed for initialization.
+      #
+      class OptionsAssigner
+        def initialize(service, options)
+          @service = service
+          @options = options
+        end
+
+        def assign_options!
+          check_for_missing_options!
+
+          service.class.options_configuration.each_value { |o| assign_option(o) }
+        end
+
+        private
+
+        attr_reader :service, :options
+
+        def check_for_missing_options!
+          raise(ArgumentError, <<~ERROR) unless missing_options.empty?
+            Missing required options: #{missing_options.join(', ')}
+          ERROR
+        end
+
+        def assign_option(option)
+          assigned_value = options[option.name]
+
+          service.instance_variable_set(
+            "@#{option.name}",
+            assigned_value.nil? ? option.default_value : assigned_value
+          )
+        end
+
+        def missing_options
+          required_options - options.keys
+        end
+
+        def required_options
+          service.class.required_options
+        end
+      end
+    end
+  end
+end

--- a/lib/stimpack/options_declaration/option.rb
+++ b/lib/stimpack/options_declaration/option.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Stimpack
+  module OptionsDeclaration
+    # A small value object representing an option and its configuration.
+    #
+    class Option
+      # Used in lieu of `nil` to differentiate between an option that was
+      # omitted and one that was explicitly set to `nil`.
+      #
+      MISSING_VALUE = "__missing__"
+
+      def initialize(name, required:, default:)
+        @name = name
+        @default = default
+        @required = required
+      end
+
+      attr_reader :name
+
+      def default_value
+        return nil unless default?
+
+        default.respond_to?(:call) ? default.() : default
+      end
+
+      def required?
+        required && !default?
+      end
+
+      def optional?
+        !required?
+      end
+
+      def default?
+        default != MISSING_VALUE
+      end
+
+      private
+
+      attr_reader :default, :required
+    end
+  end
+end

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stimpack
-  VERSION = "0.5.3"
+  VERSION = "0.5.4"
 end


### PR DESCRIPTION
### Maintenance

- Split child classes of `EventSource` and `OptionsDeclaration` into own files.
- Add a bunch more inline documentation for the mixins.
- Remove `EventSource` and `ResultMonad` dependencies on ActiveSupport.