### PR TITLE
Add nicely formatted inspect output for ResultMonad::Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.4
 
+### New features
+
+- Add nicely formatted inspect output for `ResultMonad::Result`.
+
 ### Maintenance
 
 - Split child classes of `EventSource` and `OptionsDeclaration` into own files.

--- a/lib/stimpack/result_monad/result.rb
+++ b/lib/stimpack/result_monad/result.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Stimpack
+  module ResultMonad
+    class Result < Struct
+      def successful?
+        errors.nil?
+      end
+
+      def failed?
+        !successful?
+      end
+
+      def inspect
+        if successful?
+          "<#{klass}:successful #{result_key} : #{self[result_key].inspect}>"
+        else
+          "<#{klass}:failed errors : #{errors.inspect}>"
+        end
+      end
+
+      private
+
+      def result_key
+        (members - %i[klass errors]).first
+      end
+    end
+  end
+end

--- a/spec/stimpack/result_monad/result_spec.rb
+++ b/spec/stimpack/result_monad/result_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "stimpack/result_monad"
+
+RSpec.describe Stimpack::ResultMonad::Result do
+  subject(:service) { klass }
+
+  let(:klass) do
+    Class.new do
+      include Stimpack::ResultMonad
+
+      result :foo
+
+      def success_result(**options)
+        success(**options)
+      end
+
+      def error_result(errors:)
+        error(errors: errors)
+      end
+
+      def self.to_s
+        "Foo"
+      end
+    end
+  end
+
+  let(:instance) { service.new }
+
+  describe "#inspect" do
+    context "when result is successful" do
+      it { expect(instance.success_result(foo: "bar").inspect).to eq("<Foo:successful foo : \"bar\">") }
+    end
+
+    context "when result is failed" do
+      it { expect(instance.error_result(errors: "Oops!").inspect).to eq("<Foo:failed errors : \"Oops!\">") }
+    end
+  end
+end

--- a/spec/stimpack/result_monad_spec.rb
+++ b/spec/stimpack/result_monad_spec.rb
@@ -75,13 +75,13 @@ RSpec.describe Stimpack::ResultMonad do
     context "when a result key is declared" do
       before { service.result(:foo) }
 
-      it { expect(service.result_struct.members).to contain_exactly(:foo, :errors) }
+      it { expect(service.result_struct.members).to contain_exactly(:foo, :errors, :klass) }
     end
 
     context "when a blank result is declared" do
       before { service.blank_result }
 
-      it { expect(service.result_struct.members).to contain_exactly(:errors) }
+      it { expect(service.result_struct.members).to contain_exactly(:errors, :klass) }
     end
   end
 


### PR DESCRIPTION
### Before

```
#<struct klass=#<Class:0x00007fbb46075900>, errors=nil, foo="bar">
#<struct klass=#<Class:0x00007fbb4b0e0de0>, errors="Oops!", foo=nil>
```

### After

```
<Foo:successful foo : "bar">
<Foo:failed errors : "Oops!">
```