### PR TITLE
Add error_handler configuration option to the EventSource module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5
+
+### New features
+
+- Add `error_handler` configuration option to the `EventSource` module.
+
 ## 0.5.4
 
 ### New features

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stimpack (0.5.4)
+    stimpack (0.5.5)
       activesupport (~> 6.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ and behaviour.
 ## Table of Contents
 
 - [EventSource](#eventsource)
+  - [Error handling](#error-handling)
 - [FunctionalObject](#functionalobject)
 - [OptionsDeclaration](#optionsdeclaration)
 - [ResultMonad](#resultmonad)
@@ -66,6 +67,21 @@ rescue StandardError => error
   log_error(error.message)
 end
 ```
+
+Alternatively, you can configure an event handler for all `EventSource` classes
+to use. The error handler needs to respond fo `#call` and will be passed a
+single argument, the error that was raised:
+
+**Example:**
+
+```ruby
+EventSource.error_handler = ->(error) { AppSignal.error(error) }
+```
+
+This can be useful for instrumentation, and to handle errors differently
+depending on which environment the code is running in.
+
+*Note: Once configured, this will apply to all listeners.*
 
 ## FunctionalObject
 

--- a/lib/stimpack/event_source.rb
+++ b/lib/stimpack/event_source.rb
@@ -20,6 +20,16 @@ module Stimpack
   #   Checkout.on(:error) { |event| Appsignal.report(event.message) }
   #
   module EventSource
+    DEFAULT_ERROR_HANDLER = ->(_error) {}
+
+    def self.error_handler
+      @error_handler || DEFAULT_ERROR_HANDLER
+    end
+
+    def self.error_handler=(handler)
+      @error_handler = handler
+    end
+
     module ClassMethods
       # Callback registry that stores a mapping of callbacks for all concrete
       # service classes. The registry is a hash that lives in the base class,

--- a/lib/stimpack/event_source/listener.rb
+++ b/lib/stimpack/event_source/listener.rb
@@ -16,6 +16,8 @@ module Stimpack
       def call(...)
         block.(...)
       rescue StandardError => e
+        EventSource.error_handler.(e)
+
         raise e if raise_errors
       end
 

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stimpack
-  VERSION = "0.5.4"
+  VERSION = "0.5.5"
 end

--- a/spec/stimpack/event_source/listener_spec.rb
+++ b/spec/stimpack/event_source/listener_spec.rb
@@ -6,6 +6,15 @@ RSpec.describe Stimpack::EventSource::Listener do
   subject(:listener) { described_class.new(raise_errors: raise_errors, &block) }
 
   let(:raise_errors) { false }
+  let(:error_handler) { instance_spy(Proc) }
+
+  before do
+    Stimpack::EventSource.error_handler = error_handler
+  end
+
+  after do
+    Stimpack::EventSource.error_handler = nil
+  end
 
   describe "#call" do
     context "when no errors are raised" do
@@ -22,11 +31,22 @@ RSpec.describe Stimpack::EventSource::Listener do
       end
 
       it { expect(receiver).to have_received(:foo).once }
+      it { expect(error_handler).not_to have_received(:call) }
     end
 
     context "when errors are raised" do
       let(:block) do
         proc { raise StandardError }
+      end
+
+      context "when an error handler is configured" do
+        let(:raise_errors) { false }
+
+        before do
+          listener.()
+        end
+
+        it { expect(error_handler).to have_received(:call).once.with(StandardError) }
       end
 
       context "when configured to raise errors" do

--- a/spec/stimpack/event_source_spec.rb
+++ b/spec/stimpack/event_source_spec.rb
@@ -15,6 +15,26 @@ RSpec.describe Stimpack::EventSource do
     end
   end
 
+  describe ".error_handler" do
+    context "when no error handler has been configured" do
+      it { expect(described_class.error_handler).to respond_to(:call) }
+    end
+
+    context "when an error handler has been configured" do
+      let(:error_handler) { instance_double(Proc) }
+
+      before do
+        described_class.error_handler = error_handler
+      end
+
+      after do
+        described_class.error_handler = nil
+      end
+
+      it { expect(described_class.error_handler).to eq(error_handler) }
+    end
+  end
+
   describe ".on" do
     it { expect { service.on(:foo) {} }.to change { klass.event_listeners["Foo.foo"].size }.by(1) }
   end


### PR DESCRIPTION
You can now configure an event handler for all `EventSource` classes to use. The error handler needs to respond fo `#call` and will be passed a single argument, the error that was raised:

**Example:**

```ruby
Stimpack::EventSource.error_handler = ->(error) { AppSignal.error(error) }
```

This can be useful for instrumentation, and to handle errors differently depending on which environment the code is running in.

*Note: Once configured, this will apply to all listeners.*