### PR TITLE
Revert failed removal of ActiveSupport#class_attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.6
+
+### Bug fixes
+
+- Add back dependency on `ActiveSupport#class_attribute` which was dropped
+  prematurely.
+
 ## 0.5.5
 
 ### New features

--- a/lib/stimpack/event_source.rb
+++ b/lib/stimpack/event_source.rb
@@ -38,11 +38,11 @@ module Stimpack
       #
       def self.extended(klass)
         klass.class_eval do
-          @event_listeners = Hash.new { |h, k| h[k] = [] }
-
-          class << self
-            attr_reader :event_listeners
-          end
+          # TODO: Remove dependency on ActiveSupport.
+          #
+          class_attribute :event_listeners,
+                          instance_accessor: false,
+                          default: Hash.new { |h, k| h[k] = [] }
         end
       end
 

--- a/lib/stimpack/result_monad.rb
+++ b/lib/stimpack/result_monad.rb
@@ -51,11 +51,11 @@ module Stimpack
       #
       def self.extended(klass)
         klass.class_eval do
-          @callbacks = Hash.new { |h, k| h[k] = [] }
-
-          class << self
-            attr_reader :callbacks
-          end
+          # TODO: Remove dependency on ActiveSupport.
+          #
+          class_attribute :callbacks,
+                          instance_accessor: false,
+                          default: Hash.new { |h, k| h[k] = [] }
         end
       end
 

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stimpack
-  VERSION = "0.5.5"
+  VERSION = "0.5.6"
 end


### PR DESCRIPTION
I thought we were ready to remove this, but the replacement does not work in the case where Stimpack modules are mixed into a base class which is then inherited.