### PR TITLE
Add new transform option to OptionsDeclaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.0
+
+### New features
+
+- Add support for transformation methods to `OptionsDeclaration`.
+
 ## 0.5.6
 
 ### Bug fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    stimpack (0.5.5)
+    stimpack (0.6.0)
       activesupport (~> 6.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.3)
+    activesupport (6.1.3.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -16,7 +16,7 @@ GEM
     ast (2.4.2)
     concurrent-ruby (1.1.8)
     diff-lcs (1.4.4)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     minitest (5.14.4)
     parallel (1.20.1)

--- a/README.md
+++ b/README.md
@@ -152,11 +152,62 @@ Foo.new(bar: "Hello!")
 
 When declaring an option, the following configuration kets are available:
 
-| Configuration    | Type         | Default | Notes |
-| ---------------  | ------------ | ------- | ----- |
-| `default`        | `any`        | `nil`   | Can be a literal or a callable object. Arrays and hashes will not be shared across instances. |
-| `required`       | `boolean`    | `true`  | |
-| `private_reader` | `boolean`    | `true`  | |
+| Configuration    | Type            | Default | Notes |
+| ---------------  | --------------- | ------- | ----- |
+| `default`        | `any`           | `nil`   | Can be a literal or a callable object. Arrays and hashes will not be shared across instances. |
+| `required`       | `boolean`       | `true`  | |
+| `transform`      | `symbol`/`proc` | `noop`  | Can be a symbol that is a method on the value, or a callable object that takes the value as argument. |
+| `private_reader` | `boolean`       | `true`  | |
+
+### Transformations
+
+You can declare transformations which will be performed on the value when
+assigned. This also works with default values. (The transformation will be
+applied to the default value.)
+
+**Example:**
+
+Given the following declaration:
+
+```ruby
+class Foo
+  include Stimpack::OptionsDeclaration
+
+  option :bar, transform: ->(value) { value.upcase }
+end
+```
+
+values assigned to `bar` will now be upcased:
+
+```ruby
+foo = Foo.new(bar: "baz")
+
+foo.bar
+#=> "BAZ"
+```
+
+You can also use the name of method on the value, passed as a symbol.
+
+**Example:**
+
+Given the following declaration:
+
+```ruby
+class Foo
+  include Stimpack::OptionsDeclaration
+
+  option :bar, transform: :symbolize_keys
+end
+```
+
+hashes assigned to `bar` will now have their keys symbolized:
+
+```ruby
+foo = Foo.new(bar: { "baz" => "qux" })
+
+foo.bar
+#=> { baz: "qux" }
+```
 
 ## ResultMonad
 

--- a/lib/stimpack/options_declaration.rb
+++ b/lib/stimpack/options_declaration.rb
@@ -56,7 +56,14 @@ module Stimpack
       #     option :user
       #   end
       #
-      def option(*identifiers, required: true, default: Option::MISSING_VALUE, private_reader: true) # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/MethodLength
+      def option(
+        *identifiers,
+        required: true,
+        default: Option::MISSING_VALUE,
+        transform: Option::NO_TRANSFORM,
+        private_reader: true
+      )
         self.options_configuration = options_configuration.merge(
           identifiers.map do |identifier|
             [
@@ -64,7 +71,8 @@ module Stimpack
               Option.new(
                 identifier.to_sym,
                 required: required,
-                default: default
+                default: default,
+                transform: transform
               )
             ]
           end.to_h
@@ -78,6 +86,7 @@ module Stimpack
           end
         end
       end
+      # rubocop:enable Metrics/MethodLength
 
       def options
         options_configuration.keys

--- a/lib/stimpack/options_declaration/initializer.rb
+++ b/lib/stimpack/options_declaration/initializer.rb
@@ -40,9 +40,11 @@ module Stimpack
         def assign_option(option)
           assigned_value = options[option.name]
 
+          value = assigned_value.nil? ? option.default_value : assigned_value
+
           service.instance_variable_set(
             "@#{option.name}",
-            assigned_value.nil? ? option.default_value : assigned_value
+            option.transformed_value(value)
           )
         end
 

--- a/lib/stimpack/options_declaration/option.rb
+++ b/lib/stimpack/options_declaration/option.rb
@@ -9,11 +9,13 @@ module Stimpack
       # omitted and one that was explicitly set to `nil`.
       #
       MISSING_VALUE = "__missing__"
+      NO_TRANSFORM = "__noop__"
 
-      def initialize(name, required:, default:)
+      def initialize(name, required:, default:, transform:)
         @name = name
         @default = default
         @required = required
+        @transform = transform
       end
 
       attr_reader :name
@@ -22,6 +24,10 @@ module Stimpack
         return nil unless default?
 
         default.respond_to?(:call) ? default.() : default
+      end
+
+      def transformed_value(value)
+        transform? ? transform.to_proc.(value) : value
       end
 
       def required?
@@ -36,9 +42,13 @@ module Stimpack
         default != MISSING_VALUE
       end
 
+      def transform?
+        transform != NO_TRANSFORM
+      end
+
       private
 
-      attr_reader :default, :required
+      attr_reader :default, :required, :transform
     end
   end
 end

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stimpack
-  VERSION = "0.5.6"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
### Transformations

You can declare transformations which will be performed on the value when
assigned. This also works with default values. (The transformation will be
applied to the default value.)

**Example:**

Given the following declaration:

```ruby
class Foo
  include Stimpack::OptionsDeclaration

  option :bar, transform: ->(value) { value.upcase }
end
```

values assigned to `bar` will now be upcased:

```ruby
foo = Foo.new(bar: "baz")

foo.bar
#=> "BAZ"
```

You can also use the name of method on the value, passed as a symbol.

**Example:**

Given the following declaration:

```ruby
class Foo
  include Stimpack::OptionsDeclaration

  option :bar, transform: :symbolize_keys
end
```

hashes assigned to `bar` will now have their keys symbolized:

```ruby
foo = Foo.new(bar: { "baz" => "qux" })

foo.bar
#=> { baz: "qux" }
```