### PR TITLE
Yield the result of the call from  if block is given.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.0
+
+### New features
+
+- Yield the result of the call from `FunctionalObject` if block is given.
+
 ## 0.7.1
 
 ### New features

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 PATH
   remote: .
   specs:
-    stimpack (0.7.0)
+    stimpack (0.8.0)
       activesupport (~> 6.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.3.2)
+    activesupport (6.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     ast (2.4.2)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     diff-lcs (1.4.4)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -119,6 +119,21 @@ Foo.(bar: "Hello world!")
 #=> "Hello world!"
 ```
 
+You can optionally pass a block to the call which will receive the result of
+the method and will execute before returning.
+
+**Note: The result is still always returned.**
+
+```ruby
+Foo.(bar: "Hello world!") do |result|
+  if result.successful?
+    # Do stuff.
+  else
+    # Report errors.
+  end
+end
+```
+
 ## OptionsDeclaration
 
 A mixin that introduces the concept of an `option`, and lets classes declare

--- a/lib/stimpack/functional_object.rb
+++ b/lib/stimpack/functional_object.rb
@@ -11,8 +11,12 @@ module Stimpack
   #
   module FunctionalObject
     module ClassMethods
-      def call(...)
-        new(...).()
+      def call(*arguments, **options)
+        result = new(*arguments, **options).()
+
+        yield result if block_given?
+
+        result
       end
     end
 

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stimpack
-  VERSION = "0.7.1"
+  VERSION = "0.8.0"
 end

--- a/spec/stimpack/functional_object_spec.rb
+++ b/spec/stimpack/functional_object_spec.rb
@@ -21,22 +21,25 @@ RSpec.describe Stimpack::FunctionalObject do
         Class.new do
           include Stimpack::FunctionalObject
 
-          def initialize(foo, bar:, &block)
+          def initialize(foo, bar:)
             @foo = foo
             @bar = bar
-            @baz = block.()
           end
 
-          attr_reader :foo, :bar, :baz
+          attr_reader :foo, :bar
 
           def call
-            [foo, bar, baz]
+            [foo, bar]
           end
         end
       end
 
       it "delegates arguments, options, and block" do
-        expect(klass.("foo", bar: "bar") { "baz" }).to eq(%w[foo bar baz])
+        expect(klass.("foo", bar: "bar") { "baz" }).to eq(%w[foo bar])
+      end
+
+      it "yields the return value to the block if given" do
+        expect { |block| klass.("foo", bar: "bar", &block) }.to yield_with_args(%w[foo bar])
       end
     end
   end


### PR DESCRIPTION
You can now optionally pass a block to the call which will receive the result of the method and will execute before returning.

**Note: The result is still always returned.**

```ruby
Foo.(bar: "Hello world!") do |result|
  if result.successful?
    # Do stuff.
  else
    # Report errors.
  end
end
```