### PR TITLE
Have GuardFailed inherit from Exception instead of StandardError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.8.2
+
+### Bug fixes
+
+- Have `GuardFailed` inherit from `Exception` instead of `StandardError`.
+
+## 0.8.1
+
+## Maintenance
+- Loosen the ActiveSupport dependency version to prepare for Rails 7.
+
 ## 0.8.0
 
 ### New features

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    stimpack (0.8.0)
+    stimpack (0.8.1)
       activesupport (>= 6.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4)
+    activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)

--- a/README.md
+++ b/README.md
@@ -359,3 +359,7 @@ long as the guards return a success `Result`, the execution continues as
 expected.
 
 *Note: Any error callbacks declared on the inner monad will also be invoked.*
+
+Guard clauses use `raise` and `rescue` internally, but the exception used is
+directly inherited from `Exception`, so it is safe to rescue anything downstream
+of that, e.g. `StandardError` in your methods which have guard clauses.

--- a/lib/stimpack/result_monad/guard_clause.rb
+++ b/lib/stimpack/result_monad/guard_clause.rb
@@ -39,7 +39,7 @@ module Stimpack
       # guard fails. It carries the error result with it, and passes it to the
       # caller which can then work with it.
       #
-      class GuardFailed < StandardError
+      class GuardFailed < Exception # rubocop:disable Lint/InheritException
         # rubocop:disable Lint/MissingSuper
         def initialize(result)
           @result = result

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stimpack
-  VERSION = "0.8.1"
+  VERSION = "0.8.2"
 end

--- a/spec/stimpack/result_monad/guard_clause_spec.rb
+++ b/spec/stimpack/result_monad/guard_clause_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe Stimpack::ResultMonad::GuardClause do
         baz_result = guard { baz }
 
         success(foo: bar_result + baz_result)
+      rescue StandardError
+        error(errors: "Something went wrong, but not a guard fail.")
       end
 
       private


### PR DESCRIPTION
### Background:

In NN we rescue `StandardError` in checkout classes in order to prevent having orders stuck in the wrong status in the case of an unexpected error.

This would also swallow up `GuardFailed` exceptions and shadow the `rescue` that makes them work.

In this PR we change `GuardFailed` to be an `Exception` instead of a `StandardError` to fix this.