### PR TITLE
Allow listen multiple event names for EventSource listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.3
+
+### New features
+
+- Listen on multiple event names to `EventSource` listener.
+
 ## 0.8.2
 
 ### Bug fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stimpack (0.8.1)
+    stimpack (0.8.3)
       activesupport (>= 6.1)
 
 GEM
@@ -54,10 +54,11 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
 
 DEPENDENCIES
   rake (~> 13.0)

--- a/README.md
+++ b/README.md
@@ -39,11 +39,15 @@ we can register a callback to listen for events from another part of our
 application, and we will receive an event object when the event is emitted:
 
 ```ruby
-Foo.on(:bar) do |event|
+Foo.on(:bar, :qui, :qux) do |event|
   puts event.message
 end
 
 Foo.new.bar
+#=> "Hello, world!"
+Foo.new.qui
+#=> "Hello, world!"
+Foo.new.qux
 #=> "Hello, world!"
 ```
 

--- a/lib/stimpack/event_source.rb
+++ b/lib/stimpack/event_source.rb
@@ -46,10 +46,12 @@ module Stimpack
         end
       end
 
-      def on(event_name, raise_errors: false, &block)
+      def on(*event_names, raise_errors: false, &block)
         listener = Listener.new(raise_errors: raise_errors, &block)
 
-        event_listeners["#{self}.#{event_name}"] << listener
+        event_names.each do |event_name|
+          event_listeners["#{self}.#{event_name}"] << listener
+        end
       end
     end
 

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stimpack
-  VERSION = "0.8.2"
+  VERSION = "0.8.3"
 end

--- a/spec/stimpack/event_source_spec.rb
+++ b/spec/stimpack/event_source_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "stimpack/event_source"
+require "active_support/core_ext/class/attribute"
 
 RSpec.describe Stimpack::EventSource do
   subject(:service) { klass }
@@ -36,7 +37,13 @@ RSpec.describe Stimpack::EventSource do
   end
 
   describe ".on" do
-    it { expect { service.on(:foo) {} }.to change { klass.event_listeners["Foo.foo"].size }.by(1) }
+    context "with single event" do 
+      it { expect { service.on(:foo) {} }.to change { klass.event_listeners["Foo.foo"].size }.by(1) }
+    end
+
+    context "with multiple events" do
+      it { expect { service.on(:foo, :bar, :qux) {} }.to change { klass.event_listeners["Foo.foo"].size }.by(1).and change { klass.event_listeners["Foo.bar"].size }.by(1).and change { klass.event_listeners["Foo.qux"].size }.by(1) }
+    end
   end
 
   describe "#emit" do


### PR DESCRIPTION
## Background

For the event listener, we can allow passing multiple arguments instead of a single argument for now. This help a lot for multiple events that have the same business logic