### PR TITLE
Make ResultMonad callbacks inherited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.0
+
+### New features
+
+- `ResultMonad` callbacks (`before_success`, `before_error`) are now inherited.
+
 ## 0.8.3
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -291,8 +291,8 @@ The `ResultMonad` mixin exposes two callbacks, `before_success` and
 `before_error`. These can be configured by passing a block to them in the
 class body.
 
-*Note: Callbacks are not inherited, and declaring multiple callbacks in the
-same class will overwrite the previous one.*
+*Note: Declaring an already declared callback in the same class will overwrite
+the previous one.*
 
 **Example:**
 
@@ -314,6 +314,37 @@ end
 
 *Note: The block is evaluated in the context of the instance, so you can call
 any instance methods from inside the block.*
+
+Callbacks are inherited, and all inherited callbacks will be invoked as they
+are traversed up the inheritance chain. In this case, all callbacks are
+evaluated in the context of the class where the `success` or `error` method
+was called.
+
+**Example:**
+
+```ruby
+class Foo
+  include Stimpack::ResultMonad
+
+  before_success do
+    puts "Parent"
+  end
+end
+
+class Bar < Foo
+  before_success do
+    puts "Child"
+  end
+
+  def call
+    success
+  end
+end
+
+Bar.()
+#=> "Child"
+#=> "Parent"
+```
 
 ### Guard clauses
 

--- a/lib/stimpack/result_monad.rb
+++ b/lib/stimpack/result_monad.rb
@@ -174,9 +174,11 @@ module Stimpack
     end
 
     def run_callback(name)
-      callback = self.class.callbacks["#{self.class}.#{name}"]
+      self.class.ancestors.each do |ancestor|
+        callback = self.class.callbacks["#{ancestor}.#{name}"]
 
-      instance_exec(&callback) if callback.respond_to?(:call)
+        instance_exec(&callback) if callback.respond_to?(:call)
+      end
     end
   end
 end

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stimpack
-  VERSION = "0.8.3"
+  VERSION = "0.9.0"
 end


### PR DESCRIPTION
Callbacks are now inherited, and all inherited callbacks will be invoked as they are traversed up the inheritance chain. In this case, all callbacks are evaluated in the context of the class where the `success` or `error` method was called.

**Example:**

```ruby
class Foo
  include Stimpack::ResultMonad

  before_success do
    puts "Parent"
  end
end

class Bar < Foo
  before_success do
    puts "Child"
  end

  def call
    success
  end
end

Bar.()
#=> "Child"
#=> "Parent"
```