### PR TITLE
Add `after_success` and `after_error` into ResultMonad callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.10.0
+
+### New features
+
+- `ResultMonad` is added (`after_success`, `after_error`) callbacks.
+
 ## 0.9.1
 
 ### Bug fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stimpack (0.9.1)
+    stimpack (0.10.0)
       activesupport (>= 6.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -287,9 +287,9 @@ end
 
 ### Callbacks
 
-The `ResultMonad` mixin exposes two callbacks, `before_success` and
-`before_error`. These can be configured by passing a block to them in the
-class body.
+The `ResultMonad` mixin exposes four callbacks, `before_success`, `after_success`,
+`before_error` and `after_error`. These can be configured by passing a block to 
+them in the class body.
 
 *Note: Declaring an already declared callback in the same class will overwrite
 the previous one.*

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stimpack
-  VERSION = "0.9.1"
+  VERSION = "0.10.0"
 end

--- a/spec/stimpack/result_monad_spec.rb
+++ b/spec/stimpack/result_monad_spec.rb
@@ -139,6 +139,54 @@ RSpec.describe Stimpack::ResultMonad do
     end
   end
 
+  describe ".after_success" do
+    let(:instance) { service.new }
+    let(:accumulator) { spy }
+
+    before do
+      allow(instance).to receive(:accumulator).and_return(accumulator)
+
+      allow(accumulator).to receive(:callback)
+      allow(accumulator).to receive(:parent_callback)
+
+      service.blank_result
+      service.after_success { accumulator.callback }
+
+      super_klass.after_success { accumulator.parent_callback }
+
+      instance.success_result
+    end
+
+    it "runs the callbacks up the class hierarchy" do
+      expect(accumulator).to have_received(:callback).ordered
+      expect(accumulator).to have_received(:parent_callback).ordered
+    end
+  end
+
+  describe ".after_error" do
+    let(:instance) { service.new }
+    let(:accumulator) { spy }
+
+    before do
+      allow(instance).to receive(:accumulator).and_return(accumulator)
+
+      allow(accumulator).to receive(:callback)
+      allow(accumulator).to receive(:parent_callback)
+
+      service.blank_result
+      service.after_error { accumulator.callback }
+
+      super_klass.after_error { accumulator.parent_callback }
+
+      instance.error_result(errors: ["foo"])
+    end
+
+    it "runs the callbacks up the class hierarchy" do
+      expect(accumulator).to have_received(:callback).ordered
+      expect(accumulator).to have_received(:parent_callback).ordered
+    end
+  end
+
   describe "#success" do
     before { service.result(:foo) }
 


### PR DESCRIPTION
ResultMonad now has four callbacks:
- `before_success`
- `before_error`
- `after_success`
- `after_error`