### PR TITLE
Prevent duplicate invocation of the error callback when guarding an instance method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.9.2
+
+### Bug fixes
+
+- Prevent duplicate invocation of the error callback when guarding an instance
+  method.
+
 ## 0.9.1
 
 ### Bug fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,19 @@
 PATH
   remote: .
   specs:
-    stimpack (0.9.1)
+    stimpack (0.9.2)
       activesupport (>= 6.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.2.2)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     diff-lcs (1.4.4)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)

--- a/lib/stimpack/result_monad/guard_clause.rb
+++ b/lib/stimpack/result_monad/guard_clause.rb
@@ -29,7 +29,11 @@ module Stimpack
         def call
           super
         rescue GuardFailed => e
-          run_callback(:error)
+          # Avoid running the error callback in the case where it was already
+          # called by using `#error` in an instance method that is guarded
+          # against in the `#call` method.
+          #
+          run_callback(:error) unless e.result.klass == self.class
 
           e.result
         end

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stimpack
-  VERSION = "0.9.1"
+  VERSION = "0.9.2"
 end


### PR DESCRIPTION
### What was happening?

When guarding an instance method that fails using `#error`, the error callback is invoked twice: once from the call to `#error` and once when `GuardCatcher` catches the error to break the flow.

### How does this fix it?

Don't invoke callbacks in `GuardCatcher` if the error was constructed in the same class.